### PR TITLE
Add legacy swift 2.3 to allow Xcode 8.2.1 to build

### DIFF
--- a/yo.xcodeproj/project.pbxproj
+++ b/yo.xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.sheagcraig.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -407,6 +408,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.sheagcraig.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Allows Xcode 8.2.1 to build legacy version of Yo until Swift 3 refactor.

Xcode will whine but it's fine.

Fixes both https://github.com/sheagcraig/yo/issues/17 and https://github.com/sheagcraig/yo/issues/14