### PR TITLE
Yo bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Yo, as called through the `yo_scheduler`, has the following arguments. The only 
 
 Test all notifications prior to delivery, as the maximum line-length of characters differs for the title, subtitle, and info fields, which in turn can be compressed even shorter when the length of the action or cancel buttons grows beyond 8 characters.
 
+For environments where `yo.app` is not available in it's standard install location of `/Applications/Utilities/`, you can pass the `--yo-bin` argument with the absolute path to your environments' `yo.app/Contents/MacOS/yo` binary.
+
 This notification demonstrates the available content areas. Not all of these are required!
 ![Yo example](https://github.com/sheagcraig/yo/blob/testing/docs/NotificationAreas.png?raw=true)
 

--- a/pkg/yo_scheduler.py
+++ b/pkg/yo_scheduler.py
@@ -120,6 +120,10 @@ def main():
     # yo_scheduler (this script) args from the yo app's args.
     launcher_args, yo_args = parser.parse_known_args()
 
+    # Check if --yo-bin arg was passed with alternate binary location
+    if len(vars(launcher_args)["yo_bin"]) > 0:
+        globals().update(YO_BINARY=vars(launcher_args)["yo_bin"])
+
     if any(flag in yo_args for flag in ("--version", "-v")):
         # Skip further checks if version is requested.
         run_yo_with_args(yo_args)
@@ -168,6 +172,8 @@ def get_argument_parser():
     parser.add_argument("--cached", help=phelp, action="store_true")
     phelp = "Remove all cached notifications (must be run as root)."
     parser.add_argument("--cleanup", help=phelp, action="store_true")
+    phelp = "Provide yo_scheduler with a specific Yo binary path."
+    parser.add_argument("--yo-bin", help=phelp, action="store")
 
     # The parser's epilog is where we put all of the real argument help.
     parser.epilog = YO_HELP


### PR DESCRIPTION
In some environments, Yo will not be installed in the standard location of `/Applications/Utilities/yo.app`. The purpose of this PR is to provide an additional cmd arg of `--yo-bin` an Administrator can provide with the path to the Yo binary without modifying the `yo_scheduler.py` file.