### PR TITLE
Change from KeepAlive to WatchPaths

### DIFF
--- a/pkg/com.sheagcraig.yo.on_demand.plist
+++ b/pkg/com.sheagcraig.yo.on_demand.plist
@@ -13,13 +13,9 @@
     <string>/usr/local/bin/yo_scheduler</string>
     <string>--cached</string>
   </array>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/.com.sheagcraig.yo.on_demand.launchd</key>
-       <true/>
-     </dict>
-  </dict>
+  <key>WatchPaths</key>
+  <array>
+    <string>/var/run/com.sheagcraig.yo.on_demand.launchd</string>
+  </array>
 </dict>
 </plist>

--- a/pkg/postinstall
+++ b/pkg/postinstall
@@ -1,4 +1,17 @@
 #!/bin/bash
 
+[[ $3 != "/" ]] && exit 0
+
 # Rename yo.sh to yo so we can call it like a regular cli utility.
 mv /usr/local/bin/yo_scheduler.py /usr/local/bin/yo_scheduler
+
+# Load our launch agemts in the background for the logged in user
+CONSOLE_UID=`/usr/bin/stat -f%u /dev/console`
+if [ $CONSOLE_UID -gt 499 ]; then
+	/bin/launchctl asuser $CONSOLE_UID \
+		/bin/launchctl load -w \
+			/Library/LaunchAgents/com.sheagcraig.yo.login_once.plist
+	/bin/launchctl asuser $CONSOLE_UID \
+		/bin/launchctl load -w \
+			/Library/LaunchAgents/com.sheagcraig.yo.on_demand.plist
+fi

--- a/pkg/preinstall
+++ b/pkg/preinstall
@@ -5,3 +5,8 @@
 rm -rf /Applications/Utilities/yo.app
 rm -rf /Applications/Utilities/yo
 rm -rf /Applications/Utilities/yo.localized
+
+WATCH_PATH="$3/var/run/com.sheagcraig.yo.on_demand.launchd"
+
+touch "$WATCH_PATH"
+chmod a+w "$WATCH_PATH"

--- a/pkg/yo_scheduler.py
+++ b/pkg/yo_scheduler.py
@@ -63,7 +63,7 @@ from SystemConfiguration import SCDynamicStoreCopyConsoleUser
 
 __version__ = "2.0.0"
 BUNDLE_ID = "com.sheagcraig.yo"
-WATCH_PATH = "/private/tmp/.com.sheagcraig.yo.on_demand.launchd"
+WATCH_PATH = "/var/run/com.sheagcraig.yo.on_demand.launchd"
 YO_BINARY = "/Applications/Utilities/yo.app/Contents/MacOS/yo"
 # This is captured straight from running the Yo binary and must be
 # updated manually.
@@ -283,8 +283,8 @@ def touch_watch_path(path):
     with open(path, "w") as ofile:
         ofile.write("Yo!")
     # Give the LaunchDaemon a chance to work before cleaning up.
-    time.sleep(5)
-    os.remove(path)
+    # time.sleep(5)
+    # os.remove(path)
 
 
 def exit_if_not_root():

--- a/pkg/yo_scheduler.py
+++ b/pkg/yo_scheduler.py
@@ -196,7 +196,7 @@ def process_notifications():
                 cached_args[arg_set] != receipts[arg_set]:
             args = eval(arg_set) # pylint: disable=eval-used
             run_yo_with_args(args)
-            add_receipt(args)
+            add_receipt(args, cached_args[arg_set])
 
 
 def get_scheduled_notifications():
@@ -249,14 +249,16 @@ def get_receipts():
     return dict(receipts) if receipts else {}
 
 
-def add_receipt(yo_args):
+def add_receipt(yo_args, stamp=None):
     """Add a receipt to current user's receipt preferences.
 
     Args:
         yo_args (list of str): Arguments to yo app as for a subprocess.
     """
     receipts = get_receipts()
-    receipts[repr(yo_args)] = NSDate.alloc().init()
+    if stamp == None:
+        stamp = NSDate.alloc().init()
+    receipts[repr(yo_args)] = stamp
     CFPreferencesSetAppValue("DeliveryReceipts", receipts, BUNDLE_ID)
     CFPreferencesAppSynchronize(BUNDLE_ID)
 

--- a/pkg/yo_scheduler.py
+++ b/pkg/yo_scheduler.py
@@ -192,7 +192,8 @@ def process_notifications():
     receipts = get_receipts()
 
     for arg_set in cached_args:
-        if arg_set not in receipts:
+        if arg_set not in receipts or \
+                cached_args[arg_set] != receipts[arg_set]:
             args = eval(arg_set) # pylint: disable=eval-used
             run_yo_with_args(args)
             add_receipt(args)


### PR DESCRIPTION
Change from KeepAlive to WatchPaths.

yo exits immediately i think. yo_scheduler had a 5 second timeout before it deletes the watch file. because it's a KeepAlive the yo notifications would post immediately, it would exit, launchd would wait 10 seconds before starting it again, which it did (displaying potentially two updates), but then the watch file would be deleted after five seconds, so it wouldn't start it a third time. avoid the file-exists-KeepAlive problem altogether by maintaining a WatchPaths path instead.

Also start our LaunchAgents in the background if there's a logged in user.